### PR TITLE
Add setting to hide notifications

### DIFF
--- a/src/Main.as
+++ b/src/Main.as
@@ -41,7 +41,7 @@ void MainCoro() {
         bd.WaitMessage_Ok();
         sleep(50);
         bd.AskYesNo_Yes();
-        Notify("Auto-cancelled download: " + filename);
+        if (S_ShowNotification) Notify("Auto-cancelled download: " + filename);
     }
 }
 

--- a/src/Settings.as
+++ b/src/Settings.as
@@ -3,3 +3,6 @@ bool S_Enabled = true;
 
 [Setting category="General" name="Only auto-cancel car skin downloads?"]
 bool S_OnlyCancelCarSkins = true;
+
+[Setting category="General" name="Show a notification"]
+bool S_ShowNotification = true;


### PR DESCRIPTION
Hey there,

This plugin is a great time saver, but it could be even better if it worked seamlessly. This PR adds a simple notification toggle in the settings (notifications on by default) to remove the distracting pop-ups. Most of the time I don't really care about what gets cancelled.